### PR TITLE
[Issue 40] Calendar could not handle incomplete data

### DIFF
--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -13,9 +13,13 @@ import { HOURS, MINUTES } from "../constants"
 import localJSON from "./dummy_data.json"
 import { EventInvites } from "../components/EventInvites"
 import moment from "moment";
+import { getRoomIdFromPath } from "../components/Utility"
+
 var Rainbow = require("rainbowvis.js")
 
 const dbRef = db.ref()
+// DayPilotCalendar API Reference --> https://api.daypilot.org/daypilot-calendar-viewtype/
+
 
 //password: thirtythree333333***
 const SAMPLE_EMAIL_ADDRESS = ["find.a.time1@gmail.com"];
@@ -28,11 +32,6 @@ const SAMPLE_EMAIL_ADDRESS = ["find.a.time1@gmail.com"];
  * @return boolean
  */
 const checkIfDataExists =(snap,roomId) =>{
-
-  console.log('rooms' in snap.val());
-
-
-
   return (('rooms' in snap.val())
       && (ROOM_ID.toString() in snap.val()['rooms'])
       && 'data' in snap.val()['rooms'][ROOM_ID])
@@ -84,6 +83,7 @@ const createDayArr = (start, end) => {
 
 class Calendar extends Component {
   constructor(props) {
+
     super(props)
     this.state = {
       eventClicked: false,
@@ -112,6 +112,9 @@ class Calendar extends Component {
 
     // callback function for EventInvite
     this.eventInviteOnCloseCallback = this.eventInviteOnCloseCallback.bind(this)
+
+    // get the roomId
+    this.roomId = getRoomIdFromPath();
   }
 
   /**
@@ -126,20 +129,20 @@ class Calendar extends Component {
 
     if ((snap.val())) {
 
-      startDate =snap.val().rooms[ROOM_ID].time_interval.start;
-      endDate = snap.val().rooms[ROOM_ID].time_interval.end;
+      startDate =snap.val().rooms[this.roomId].time_interval.start;
+      endDate = snap.val().rooms[this.roomId].time_interval.end;
 
-      users = snap.val().rooms[ROOM_ID].users;
+      users = snap.val().rooms[this.roomId].users;
       dates = createDayArr(
           startDate,
           endDate
       );
 
 
-      if (checkIfDataExists(snap,ROOM_ID)){
+      if (checkIfDataExists(snap,this.roomId)){
 
         // add empty date to the  `events` object for all the days with missing days if there is any.
-        events = snap.val().rooms[ROOM_ID].data;
+        events = snap.val().rooms[this.roomId].data;
         let _startDate = moment(startDate, DATE_FORMAT);
         let _endDate = moment( endDate, DATE_FORMAT);
         let date;
@@ -267,9 +270,6 @@ class Calendar extends Component {
   onEventDoubleClick = eventData => {
     const startSelected = eventData.e.data.start.value;
     const endSelected = eventData.e.data.end.value;
-    //console.log("testing")
-    //console.log(eventData);
-     console.log(eventData.e.data);
     // console.log(eventData.e.data.start.value)
     // console.log(eventData.e.data.end.value)
     //console.log(this.state.eventClicked)
@@ -292,9 +292,7 @@ class Calendar extends Component {
       }
     })
 
-    //console.log("here1")
-    //console.log(state)
-  }
+  };
 
   /**
    * callback function for EventInvites. Called when the popup window closes
@@ -302,7 +300,7 @@ class Calendar extends Component {
    */
   eventInviteOnCloseCallback = () => {
     this.setState({ eventClicked: false })
-  }
+  };
 
   render() {
     return (
@@ -312,6 +310,7 @@ class Calendar extends Component {
           ref={component => {
             this.calendar = component && component.control
           }}
+
           onEventClick={this.onEventDoubleClick}
         />
         {this.state.eventClicked && (

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -125,32 +125,34 @@ class Calendar extends Component {
 
     if ((snap.val())) {
 
-      startDate = moment(snap.val().rooms[ROOM_ID].time_interval.start, DATE_FORMAT);
-      endDate = moment( snap.val().rooms[ROOM_ID].time_interval.end, DATE_FORMAT);
+      startDate =snap.val().rooms[ROOM_ID].time_interval.start;
+      endDate = snap.val().rooms[ROOM_ID].time_interval.end;
 
       users = snap.val().rooms[ROOM_ID].users;
       dates = createDayArr(
-          startDate.format(DATE_FORMAT),
-          endDate.format(DATE_FORMAT)
+          startDate,
+          endDate
       );
 
+      
       if (checkIfDataExists(snap,ROOM_ID)){
 
+        // add empty date to the  `events` object for all the days with missing days if there is any.
         events = snap.val().rooms[ROOM_ID].data;
-
-        // add empty date to events object for all the days with missing days if there is any.
+        let _startDate = moment(startDate, DATE_FORMAT);
+        let _endDate = moment( endDate, DATE_FORMAT);
         let date;
-        for (let m =startDate; m.diff(endDate, 'days') <= 0; m.add(1, 'days')) {
+        for (let m =_startDate; m.diff(_endDate, 'days') <= 0; m.add(1, 'days')) {
           date = m.format(DATE_FORMAT);
           if (!(date in events)){
             events[date]={};
           }
         }
 
-        this.renderCalender({ events:events, startDate:startDate.format(DATE_FORMAT), dates:dates, users:users })
+        this.renderCalender( {events, startDate, dates, users})
       }else{
         events =null;
-        this.renderCalender({ events:events, startDate:startDate.format(DATE_FORMAT), dates:dates, users:users })
+        this.renderCalender( {events, startDate, dates, users})
       }
     }
   };
@@ -239,6 +241,8 @@ class Calendar extends Component {
       })
     }
 
+    console.log(startDate)
+    console.log(freeTimes)
     this.setState({
       startDate: startDate,
       events: freeTimes,

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React, {Component, useContext} from "react"
 import {
   DayPilot,
   DayPilotCalendar,
@@ -14,6 +14,7 @@ import localJSON from "./dummy_data.json"
 import { EventInvites } from "../components/EventInvites"
 import moment from "moment";
 import { getRoomIdFromPath } from "../components/Utility"
+import { UserContext } from "../context/UserContext"
 
 var Rainbow = require("rainbowvis.js")
 
@@ -115,6 +116,9 @@ class Calendar extends Component {
 
     // get the roomId
     this.roomId = getRoomIdFromPath();
+
+
+
   }
 
   /**
@@ -302,7 +306,20 @@ class Calendar extends Component {
     this.setState({ eventClicked: false })
   };
 
-  render() {
+  /**
+   * Self explanatory - if user is not logged in it turns off eventClicked
+   */
+  componentDidUpdate(prevProps, prevState , snapshot) {
+    if (prevState.eventClicked !== this.state.eventClicked) {
+      if (!(this.props.isUserLoaded)){
+        this.setState({eventClicked: false});
+      }
+    }
+  };
+
+  render()
+  {
+
     return (
       <div className="calendar__container">
         <DayPilotCalendar
@@ -310,10 +327,9 @@ class Calendar extends Component {
           ref={component => {
             this.calendar = component && component.control
           }}
-
           onEventClick={this.onEventDoubleClick}
         />
-        {this.state.eventClicked && (
+        {(this.state.eventClicked && this.props.isUserLoaded) && (
           <EventInvites
             eventData={this.state.eventData}
             eventClicked={this.state.eventClicked}

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -87,7 +87,8 @@ class Calendar extends Component {
     super(props)
     this.state = {
       eventClicked: false,
-      viewType: "Week",
+      viewType: "Days",
+      days:"7",
       durationBarVisible: true,
       onTimeRangeSelected: args => {
         let selection = this.calendar
@@ -134,7 +135,7 @@ class Calendar extends Component {
           endDate
       );
 
-      
+
       if (checkIfDataExists(snap,ROOM_ID)){
 
         // add empty date to the  `events` object for all the days with missing days if there is any.
@@ -241,8 +242,6 @@ class Calendar extends Component {
       })
     }
 
-    console.log(startDate)
-    console.log(freeTimes)
     this.setState({
       startDate: startDate,
       events: freeTimes,

--- a/src/components/Utility/getRoomIdFromPath.js
+++ b/src/components/Utility/getRoomIdFromPath.js
@@ -1,0 +1,10 @@
+
+/**
+ * Get roomId from the path
+ * @returns {string} the roomId taken from the path
+ */
+const getRoomIdFromPath = () => {
+    return window.location.pathname.split("/")[2]
+};
+
+export default getRoomIdFromPath;

--- a/src/components/Utility/index.js
+++ b/src/components/Utility/index.js
@@ -1,2 +1,6 @@
+
 export { default as firebaseEmailToNormalEmail } from "./firebaseEmailToNormalEmail"
 export { default as normalEmailToFirebaseEmail } from "./normalEmailToFirebaseEmail"
+export { default as getRoomIdFromPath } from "./getRoomIdFromPath"
+
+

--- a/src/views/EventPage/EventPage.js
+++ b/src/views/EventPage/EventPage.js
@@ -39,7 +39,7 @@ const EventPage = () => {
 
         <AuthButton />
       </div>
-      <Calendar />
+      <Calendar isUserLoaded={userContext.isUserLoaded}/>
     </div>
   )
 }

--- a/src/views/EventPage/EventPage.js
+++ b/src/views/EventPage/EventPage.js
@@ -3,19 +3,12 @@ import { AuthButton } from "components/AuthButton"
 import { Event } from "components/Event"
 import Calendar from "calendar/Calendar"
 import { AddUserToRoom } from "../../components/Db"
-import { normalEmailToFirebaseEmail } from "../../components/Utility"
+import { normalEmailToFirebaseEmail,getRoomIdFromPath } from "../../components/Utility"
 import { UserContext } from "../../context/UserContext"
 
-/**
- * Get roomId from the path
- * @returns {string} the roomId taken from the path
- */
-const getRoomIdFromPath = () => {
-  return window.location.pathname.split("/")[2]
-}
 
 const EventPage = () => {
-  const userContext = useContext(UserContext)
+  const userContext = useContext(UserContext);
   //const {ListUpcomingEvents} = useContext(UserContext)
 
   /**


### PR DESCRIPTION
- Some of the days in the calendar were cut off so not all the data was showing, changed calendar from showing 'weekly' which caused the cutoff to happen, to showing 7 days. 
- Fixed the error where Calendar.js could not handle incomplete data -- incomplete ==  a day in the date_interval not having event data 
- Before the ROOM_ID for Calendar.js was hard coded, now we get it directly from the path variable
- Turned off event invites when user is not logged in