### PR TITLE
Made demo badge invisible

### DIFF
--- a/src/calendar/CalendarStyles.css
+++ b/src/calendar/CalendarStyles.css
@@ -10,3 +10,9 @@
 .calendar__container {
   margin: 32px 0;
 }
+
+.calendar_default_corner>* {
+  background: #fff !important;
+  background-color: #fff !important;
+  color: #fff !important;
+}


### PR DESCRIPTION
No more ugly orange demo badge in top left corner of calendar

<img width="1093" alt="Screen Shot 2020-01-30 at 11 52 47 AM" src="https://user-images.githubusercontent.com/24560111/73476052-2e867180-4357-11ea-9c59-1ee4b8246978.png">
