### PR TITLE
Toggle between two calendar views, closes #59

### DIFF
--- a/src/components/Event/Event.css
+++ b/src/components/Event/Event.css
@@ -1,12 +1,6 @@
 .event__creator-profile-pic {
   vertical-align: middle;
   margin-right: 8px;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
 }
 .event__creator-container {
   display: flex;
@@ -14,13 +8,15 @@
   margin-top: 8px;
 }
 
+/*MaterialUI secondart text color*/
 .event__text {
-  color: var(--black);
+  color: rgba(0, 0, 0, 0.54);
 }
 .event__container {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  margin-bottom: 24px;
 }
 
 .event__title {

--- a/src/components/Event/Event.js
+++ b/src/components/Event/Event.js
@@ -1,5 +1,7 @@
 import React from "react"
+import Typography from "@material-ui/core/Typography";
 import "./Event.css"
+import Avatar from "@material-ui/core/Avatar";
 const Event = ({
   eventName,
   eventDescription,
@@ -8,27 +10,30 @@ const Event = ({
 }) => {
   return (
     <div className="event__container">
-      <div className="event__text event__title">{eventName}</div>
-      <div className="event__creator-container">
-        <img
-          className="event__creator-profile-pic"
-          src={eventCreatorPic}
-          alt="users profile"
-        />
-        <div className="event__text">{eventCreator}</div>
-      </div>
-      <div className="event__text event__description">{eventDescription}</div>
+        <Typography variant="h3" gutterBottom color='textPrimary' className='event__title'>
+            {eventName}
+        </Typography>
+
+        <div className="event__creator-container">
+            <Avatar alt={eventCreator} src={eventCreatorPic} className="event__creator-profile-pic"/>
+            
+            <div className="event__text">{eventCreator}</div>
+        </div>
+
+        <Typography variant="body1" gutterBottom className='event__description'>
+            {eventDescription}
+        </Typography>
     </div>
   )
-}
+};
 
 Event.defaultProps = {
   eventName: "CS 394 Meeting",
   eventDescription:
     "Hey everyone! Please fill out this form whenever you can so that we can find a time to meet weekly! Make sure to connect your Google calendar so you don’t have to manually fill in events!",
-  eventCreatorPic:
-    "https://media.vanityfair.com/photos/545f9049cb308b5575a4902f/master/w_2560%2Cc_limit/matt-damon-bourne-again-rexusa_1338570b.jpg",
-  eventCreator: "Jason Bourne"
-}
+    eventCreatorPic:
+        "https://media.vanityfair.com/photos/545f9049cb308b5575a4902f/master/w_2560%2Cc_limit/matt-damon-bourne-again-rexusa_1338570b.jpg",
+    eventCreator: "Jason Bourne"
+};
 
 export default Event

--- a/src/components/Event/Event.js
+++ b/src/components/Event/Event.js
@@ -16,7 +16,7 @@ const Event = ({
 
         <div className="event__creator-container">
             <Avatar alt={eventCreator} src={eventCreatorPic} className="event__creator-profile-pic"/>
-            
+
             <div className="event__text">{eventCreator}</div>
         </div>
 

--- a/src/components/EventInvites/EventInvites.js
+++ b/src/components/EventInvites/EventInvites.js
@@ -278,7 +278,7 @@ const EventInvites = ({
                 <CardHeader
                   title={(eventHtmlLink===null)? `${humanReadableTimeDiff} Meeting`: 'Thank You'}
                   style={{ textAlign: "center" }}
-                  u
+
                 />
                 {/*Length of meeting*/}
 

--- a/src/components/ShareBanner/ShareBanner.js
+++ b/src/components/ShareBanner/ShareBanner.js
@@ -8,19 +8,14 @@ const ShareBanner = () => {
   const url = window.location.href
 
   useEffect(() => {
-    const hideElement = () => {
-      setTimeout(() => {
-        copyContainer.current.style.display = "none"
-      }, 300)
-    }
 
     if (isCopied) {
       setTimeout(() => {
-        copyContainer.current.style.opacity = "0"
-        hideElement()
+        setIsCopied(false);
       }, 1000)
     }
-  }, [isCopied])
+  }, [isCopied]);
+
   const handleCopyLink = () => {
     setIsCopied(true)
     copy(url)
@@ -28,7 +23,7 @@ const ShareBanner = () => {
   return (
     <div className="share-banner__container" ref={copyContainer}>
       <div className="share-banner__text">
-        To share this event, just send the link to all the your event members!
+        Use this link to invite people!
       </div>
       {isCopied ? (
         <div className="share-banner__button share-banner__button--copied">

--- a/src/components/ShareBanner/ShareBanner.js
+++ b/src/components/ShareBanner/ShareBanner.js
@@ -23,7 +23,7 @@ const ShareBanner = () => {
   return (
     <div className="share-banner__container" ref={copyContainer}>
       <div className="share-banner__text">
-        Use this link to invite people!
+        Share this link to invite people!
       </div>
       {isCopied ? (
         <div className="share-banner__button share-banner__button--copied">

--- a/src/components/ShareBanner/ShareBanner.scss
+++ b/src/components/ShareBanner/ShareBanner.scss
@@ -1,3 +1,5 @@
+@import "~sass-globals/variables";
+
 .share-banner__container {
   border-radius: 8px;
   border: 2px solid #214261;
@@ -9,6 +11,14 @@
   opacity: 1;
   transition: opacity 300ms ease-in;
 }
+
+@media only screen and (max-width: $mobile-break) {
+  .share-banner__container {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 
 .share-banner__text {
   font-weight: 500;

--- a/src/components/ShareBanner/ShareBanner.scss
+++ b/src/components/ShareBanner/ShareBanner.scss
@@ -4,10 +4,8 @@
   background-color: #e7f3fa;
   color: #1d4b8f;
   display: flex;
-  width: fit-content;
-  align-items: center;
+  align-self: flex-start;
   padding: 8px 18px;
-  margin: 0 auto 24px auto;
   opacity: 1;
   transition: opacity 300ms ease-in;
 }

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -323,7 +323,7 @@ class Calendar extends Component {
   {
 
     return (
-      <div className="calendar__container">
+      <div className={"calendar__container"}>
 
         <DayPilotCalendar
           {...this.state}

--- a/src/components/calendar/CalendarStyles.css
+++ b/src/components/calendar/CalendarStyles.css
@@ -8,7 +8,7 @@
 }
 
 .calendar__container {
-  margin: 32px 0;
+  margin: 0 0;
 }
 
 .calendar_default_corner>* {

--- a/src/views/EventPage/EventPage.js
+++ b/src/views/EventPage/EventPage.js
@@ -1,52 +1,66 @@
-import React, { useContext, useEffect } from "react"
-import { AuthButton } from "components/AuthButton"
-import { Event } from "components/Event"
-import { ShareBanner } from "components/ShareBanner"
+import React, {useContext, useEffect, useState} from "react"
+import {AuthButton} from "components/AuthButton"
+import {Event} from "components/Event"
+import {ShareBanner} from "components/ShareBanner"
 import Calendar from "../../components/calendar/Calendar"
 import PersonalCalendar from "../../components/PersonalCalendar/PersonalCalendar"
-import { AddUserToRoom } from "components/Db"
-import {
-  normalEmailToFirebaseEmail,
-  getRoomIdFromPath
-} from "components/Utility"
-import { UserContext } from "context/UserContext"
+import {AddUserToRoom} from "components/Db"
+import {normalEmailToFirebaseEmail, getRoomIdFromPath} from "components/Utility"
+import {UserContext} from "context/UserContext"
+import {ToggleCalendar} from "./components";
+
 
 const EventPage = () => {
-  const userContext = useContext(UserContext)
-  console.log("HERE IS THE USER CONTEXT!!!", userContext);
-  //const {ListUpcomingEvents} = useContext(UserContext)
+    const userContext = useContext(UserContext);
+    const [isPersonalCal, setIsPersonalCal] = useState(false);
+    console.log("HERE IS THE USER CONTEXT!!!", userContext);
+    //const {ListUpcomingEvents} = useContext(UserContext)
 
-  /**
-   * Adds user to room once logged in and on an EventPage by saving the email and profile pic in the roomId
-   * ToDo: ideally in the calendar code we can show names and the associated pics of people available.
-   */
-  useEffect(() => {
-    if (userContext.isUserLoaded) {
-      userContext.ListUpcomingEvents({
-        roomId: getRoomIdFromPath(),
-        userName: normalEmailToFirebaseEmail(userContext.user.email)
-      })
+    /**
+     * Adds user to room once logged in and on an EventPage by saving the email and profile pic in the roomId
+     * Calls ListUpcomingEvents() to populate calender w/ Gcal Events
+     */
+    useEffect(() => {
+        if (userContext.isUserLoaded) {
+            userContext.ListUpcomingEvents({
+                roomId: getRoomIdFromPath(),
+                userName: normalEmailToFirebaseEmail(userContext.user.email)
+            });
 
-      AddUserToRoom({
-        roomId: getRoomIdFromPath(),
-        email: normalEmailToFirebaseEmail(userContext.user.email),
-        userName: userContext.user.name,
-        picture: userContext.user.picture
-      })
-    }
-  }, [userContext.isUserLoaded])
+            AddUserToRoom({
+                roomId: getRoomIdFromPath(),
+                email: normalEmailToFirebaseEmail(userContext.user.email),
+                userName: userContext.user.name,
+                picture: userContext.user.picture
+            })
+        }
+    }, [userContext.isUserLoaded]);
 
-  return (
-    <div>
-      <ShareBanner />
-      <div className="event-auth__container">
-        <Event />
-        <AuthButton />
-      </div>
-      { userContext.user ? <PersonalCalendar isUserLoaded={userContext.isUserLoaded} user={userContext.user} /> : null }
-      <Calendar isUserLoaded={userContext.isUserLoaded}/>
-    </div>
-  )
-}
+    const onGroupAvailabilityClick = () =>{
+        setIsPersonalCal(false);
+    };
+
+    const onYourAvailabilityClick = () =>{
+        setIsPersonalCal(true);
+    };
+
+    return (
+        <div>
+
+                <div className="event-auth__container">
+                    <Event/>
+                    <ShareBanner/>
+                </div>
+                    <ToggleCalendar
+                        onGroupAvailabilityClick={onGroupAvailabilityClick}
+                        onYourAvailabilityClick={onYourAvailabilityClick}
+                        isUserLoaded={!(userContext.isUserLoaded==null)}/>
+
+                {(userContext.user && isPersonalCal)?
+                    <PersonalCalendar isUserLoaded={userContext.isUserLoaded} user={userContext.user}/> : <Calendar isUserLoaded={userContext.isUserLoaded}/>}
+
+        </div>
+    )
+};
 
 export default EventPage

--- a/src/views/EventPage/components/ToggleCalendar.js
+++ b/src/views/EventPage/components/ToggleCalendar.js
@@ -1,0 +1,79 @@
+import React,{useState} from "react"
+import "./ToggleCalendar.scss"
+import Button from "@material-ui/core/Button";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/core/styles"
+
+const useStyles = makeStyles(() => ({
+    buttonGroup:
+        {
+            border:'solid',
+            borderRadius: '5px',
+            borderWidth: '2px',
+            borderColor: '#ccc'
+        },
+    buttonActive: {
+        fontWeight:'bold',
+        background: '#44548f',
+        color:'#fff',
+        "&:hover": {
+            backgroundColor: "#374473"
+        }
+    },
+    buttonNotActive:
+        {
+            fontWeight:'normal',
+            color:'#424242',
+            background:'#ffffff',
+            "&:hover": {
+                backgroundColor: "#F5F5F5"
+            }
+        }
+}));
+
+const ToggleCalendar = ({onGroupAvailabilityClick, onYourAvailabilityClick,isUserLoaded}) =>{
+    const [isGroupAvailButton, setIsGroupAvailButton] = useState(true);
+    const classes = useStyles();
+
+    const onGroupClick = () =>{
+        onGroupAvailabilityClick();
+        setIsGroupAvailButton(true);
+    };
+
+    const onYourClick = () =>{
+        onYourAvailabilityClick();
+        setIsGroupAvailButton(false);
+    };
+
+    return (
+        <nav className="toggleCalendar__container">
+            <div className="toggleCalendar__links-container">
+                    <ButtonGroup size="large" aria-label="small outlined button group"
+                                 className={classes.buttonGroup} >
+                        <Button
+                            className={isGroupAvailButton? classes.buttonActive : classes.buttonNotActive }
+                            onClick={onGroupClick}
+                            variant="contained">
+                            Group Availability
+                        </Button>
+                        <Button
+                            className={!(isGroupAvailButton)? classes.buttonActive : classes.buttonNotActive }
+                            onClick={onYourClick}
+                            disabled={!(isUserLoaded)}
+                            variant="contained">
+                            Your Availability
+                        </Button>
+                    </ButtonGroup>
+            </div>
+        </nav>
+    )
+};
+
+ToggleCalendar.propTypes = {
+    onGroupAvailabilityClick: PropTypes.func.isRequired,
+    onYourAvailabilityClick: PropTypes.func.isRequired,
+    isUserLoaded: PropTypes.bool.isRequired
+};
+
+export default ToggleCalendar;

--- a/src/views/EventPage/components/ToggleCalendar.scss
+++ b/src/views/EventPage/components/ToggleCalendar.scss
@@ -1,0 +1,32 @@
+@import "~sass-globals/variables";
+
+.toggleCalendar__container {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 10px 32px;
+  border-top: solid;
+  border-left: solid;
+  border-right: solid;
+  border-width: 1px;
+  border-color: #ccc;
+  background: #f3f3f3;
+  margin-top: 36px;
+}
+
+.toggleCalendar__links-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: flex-start;
+}
+
+
+
+@media only screen and (max-width: $mobile-break) {
+  .toggleCalendar__links-container {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+}
+

--- a/src/views/EventPage/components/index.js
+++ b/src/views/EventPage/components/index.js
@@ -1,0 +1,1 @@
+export { default as ToggleCalendar} from "./ToggleCalendar"

--- a/src/views/YourEvents/YourEvents.scss
+++ b/src/views/YourEvents/YourEvents.scss
@@ -1,6 +1,7 @@
 @import "~sass-globals/variables";
 
 
+
 .yourevents__container-main{
   width: 600px;
   height: 98vh;
@@ -125,6 +126,8 @@
   top: 12%;
   z-index: -1;
   right:  135%;
+  animation: yourevents_fade-in 1500ms 500ms forwards;
+  animation-delay: 0ms;
 
 }
 
@@ -145,6 +148,8 @@
   bottom: 14.25%;
   opacity: 0.6;
   z-index: -1;
+  animation: yourevents_fade-in 1500ms 500ms forwards;
+  animation-delay: 0ms;
 }
 
 @media only screen and (max-width: $mobile-break) {
@@ -167,7 +172,8 @@
 
   opacity: 0.9;
   z-index: -1;
-
+  animation: yourevents_fade-in 1500ms 500ms forwards;
+  animation-delay: 0ms;
 }
 
 .yourevents_img-circle {
@@ -176,6 +182,9 @@
   right: 5.62%;
   top: 36%;
   z-index: -1;
+  animation: yourevents_fade-in 1500ms 500ms forwards;
+  animation-delay: 0ms;
+
 }
 
 @media only screen and (max-width: $mobile-break) {
@@ -203,4 +212,22 @@
   verticalAlign: middle;
   display: inline-flex;
   color: #424242;
+}
+
+
+
+@keyframes yourevents_fade-in {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  10% {
+    opacity: .5;
+    transform: translateY(20px);
+  }
+
+  100% {
+    transform: translateY(0px);
+  }
 }


### PR DESCRIPTION
closes #59 

<img width="1333" alt="Screen Shot 2020-02-01 at 1 47 48 AM" src="https://user-images.githubusercontent.com/12655844/73588930-ea00f000-4494-11ea-98f6-9796c8c47449.png">

### Toggle calendar with a few changes to other components
- In `EventPage`, added the new toggle component so that calendar's can toggle between views. 
    - The toggle is a bit clunky probably because the calendar has to re-render and stuff. 

#### Other Tingz
- I stopped `ShareBanner` from disappearing after a user copies the link. 
- **Future issue**: I checked out the code for `Events` and the Jason Bourne character is suppose to be the event owner-- this is hard coded; should use firebase to get this data
- **Issue**: `SendEvent` invites should be cleaned up but this is a low priority issue
- Removed the auth button from `EventPage` it was repetitive and at the top right we already have the login option. Also I didn't know where to put it so I deleted it.
    - **Future issue**: The avatar in the top right should give the option to sign out. It's natural to want to click on the avatar, but right now our avatar does nothing. <br> *See pic below for proposed changes...*
>> Instead of having "Account" next to the avatar we can have "Sign out" and just skip the whole drop down mess, I think this is actually the best and easiest option. (See below)
<img width="477" alt="Screen Shot 2020-02-01 at 1 28 47 AM" src="https://user-images.githubusercontent.com/12655844/73588735-4dd5e980-4492-11ea-94a0-09782543905a.png">

<img width="503" alt="Screen Shot 2020-02-01 at 1 28 42 AM" src="https://user-images.githubusercontent.com/12655844/73588734-4dd5e980-4492-11ea-9d6c-469db4718508.png">

