### PR TITLE
Making Find a Time less disgusting on mobile

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,9 @@
 @import "sass-globals/variables";
 
+body {
+  width: 100% !important;
+}
+
 .App {
   text-align: center;
 }

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -86,7 +86,7 @@ class Calendar extends Component {
     this.state = {
       eventClicked: false,
       viewType: "Days",
-      days:"7",
+      days:"4",
       durationBarVisible: true,
       onTimeRangeSelected: args => {
         let selection = this.calendar

--- a/src/components/calendar/CalendarStyles.css
+++ b/src/components/calendar/CalendarStyles.css
@@ -1,3 +1,7 @@
+tr {
+  font-size: 0.5rem !important;
+}
+
 .calendar_default_event_inner {
   background: #2e78d6;
   color: #fff;
@@ -5,6 +9,11 @@
   font-size: 10pt;
   padding: 5px;
   opacity: 0.8;
+  width: 40% !important;
+}
+
+.calendar_default_event_inner {
+  width: 100% !important;
 }
 
 .calendar__container {


### PR DESCRIPTION
Before (it would display in a weird small corner of the mobile screen):
<img width="444" alt="Screen Shot 2020-02-03 at 1 04 37 AM" src="https://user-images.githubusercontent.com/24560111/73633441-5b22dd80-4624-11ea-8eeb-4d0a30de744e.png">

After:
<img width="437" alt="Screen Shot 2020-02-03 at 1 27 47 AM" src="https://user-images.githubusercontent.com/24560111/73633461-670e9f80-4624-11ea-896c-f7d04007a728.png">

Still lots more work to do to make it more responsive, but this'll at least make it look good enough for user testing