### PR TITLE
Make buttons smaller and add more concise wording

### DIFF
--- a/src/views/EventPage/components/ToggleCalendar.js
+++ b/src/views/EventPage/components/ToggleCalendar.js
@@ -48,24 +48,25 @@ const ToggleCalendar = ({onGroupAvailabilityClick, onYourAvailabilityClick,isUse
 
     return (
         <nav className="toggleCalendar__container">
-            <div className="toggleCalendar__links-container">
-                    <ButtonGroup size="large" aria-label="small outlined button group"
-                                 className={classes.buttonGroup} >
-                        <Button
-                            className={isGroupAvailButton? classes.buttonActive : classes.buttonNotActive }
-                            onClick={onGroupClick}
-                            variant="contained">
-                            Group Availability
-                        </Button>
-                        <Button
-                            className={!(isGroupAvailButton)? classes.buttonActive : classes.buttonNotActive }
-                            onClick={onYourClick}
-                            disabled={!(isUserLoaded)}
-                            variant="contained">
-                            Your Availability
-                        </Button>
-                    </ButtonGroup>
-            </div>
+          <ButtonGroup size="small" aria-label="small outlined button group"
+                       fullWidth={true}
+                       className={classes.buttonGroup} >
+              <Button
+                  size="small"
+                  className={isGroupAvailButton? classes.buttonActive : classes.buttonNotActive }
+                  onClick={onGroupClick}
+                  variant="contained">
+                  Meeting Times
+              </Button>
+              <Button
+                  size="small"
+                  className={!(isGroupAvailButton)? classes.buttonActive : classes.buttonNotActive }
+                  onClick={onYourClick}
+                  disabled={!(isUserLoaded)}
+                  variant="contained">
+                  My Schedule
+              </Button>
+          </ButtonGroup>
         </nav>
     )
 };

--- a/src/views/EventPage/components/ToggleCalendar.scss
+++ b/src/views/EventPage/components/ToggleCalendar.scss
@@ -21,12 +21,9 @@
   align-items: flex-start;
 }
 
-
-
 @media only screen and (max-width: $mobile-break) {
   .toggleCalendar__links-container {
     flex-direction: column;
     align-items: flex-end;
   }
 }
-


### PR DESCRIPTION
On top of making the buttons smaller, I changed the wording of the tabs so that the text is all in one line instead of spilling over into two. Feel free to propose alternate wordings that will fit within one line

<img width="359" alt="Screen Shot 2020-02-03 at 4 21 18 PM" src="https://user-images.githubusercontent.com/24560111/73696130-391b7080-46a1-11ea-957d-388b311f4362.png">
