### PR TITLE
Popover now closes on touch away (for mobile) and when user makes selection

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -33,8 +33,12 @@ const POPOVER_MARGIN = 10
 const Popover = props => {
   useEffect(() => {
     document.addEventListener("mousedown", handleOutsideClick)
+    document.addEventListener("touchstart", handleOutsideClick)
 
-    return () => document.removeEventListener("mousedown", handleOutsideClick)
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick)
+      document.removeEventListener("touchstart", handleOutsideClick)
+    }
   })
 
   useEffect(() => {
@@ -89,6 +93,7 @@ const Popover = props => {
       <div
         ref={popOverRef}
         className="popover__container"
+        onClick={()=>setIsOpen(false)}
         style={{
           top: coords.y,
           left: coords.x,

--- a/src/views/YourEvents/YourEvents.scss
+++ b/src/views/YourEvents/YourEvents.scss
@@ -32,7 +32,7 @@
   width: 30%;
   margin-top: 3.5vh;
   overflow: visible;
-  z-index: 1000;
+  z-index: 9;
   left:70%;
 }
 

--- a/src/views/YourEvents/components/CondensedEvent.scss
+++ b/src/views/YourEvents/components/CondensedEvent.scss
@@ -25,13 +25,14 @@
 
 @media only screen and (max-width: $mobile-break) {
   .condensedevent__card {
-    width: 282px;
+    width: 90%;
   }
 
   .condensedevent__container-date{
     margin-right: 10px;
     font-size: .9rem;
     margin-left: -12px;
+    width: 9%;
   }
   .condensedevent__container-dateInterval{
     width: 220px;


### PR DESCRIPTION
- also changed the z-index of a component in [YouEvents] so now popover is not hidden behind a component.

closes #98 