### PR TITLE
60 calendarmoments

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -215,48 +215,27 @@ class Calendar extends Component {
                     const currUserEmail = normalEmailToFirebaseEmail(email);
                     var mtime = moment(currDay);
                     mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-                    console.log('compare', currDay, currTime, mtime)
-                    while (currDay == mtime.format('YYYY-MM-DD')){//(convertTime(currTime).concat(seconds) !== "24:00") {
-                        var test = (currDay == mtime.format('YYYY-MM-DD'))
-                        console.log("dates", currDay, mtime.format('YYYY-MM-DD'), currDay == mtime.format('YYYY-MM-DD'), test)
-                        let i = 0
-                        while (i < 2) {
-                            console.log('compare', currDay, currTime, mtime,mtime.format('HH:mm'))
-                            //strTime = currDay.concat("T", convertTime(currTime).concat(seconds))
-                            var mstrTime = currDay.concat("T",mtime.format('HH:mm'));
-                            let timeStamp = mtime.format('HH:mm');//convertTime(currTime).concat(seconds)
-                            //console.log('comparestr', strTime, mstrTime)
+                    while (currDay == mtime.format('YYYY-MM-DD')) {
+                        var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
+                        let timeStamp = mtime.format('HH:mm');
+                        if (Object.keys(events[currDay]).includes(timeStamp)) {
+                            //const unavailable = events[currDay][timeStamp]
 
-                            // CASE 1: Time slot where everybody is available
-                            if (Object.keys(events[currDay]).includes(timeStamp)) {
-                                const unavailable = events[currDay][timeStamp]
-
-                                if (Object.keys(unavailable).includes(currUserEmail)) {
-                                    console.log(currUserEmail, " is UNAVAILABLE at the time: ", timeStamp, " on day: ", currDay);
-                                    const currEvent = {
-                                        id: currId,
-                                        text: 'hi',
-                                        start: mstrTime.concat(":00"),
-                                        end: maddThirtyMin(currDay, mtime.clone()).concat(":00")//addThirtyMin(currDay, currTime, seconds).concat(":00")
-                                    }
-                                    freeTimes.push(currEvent)
+                            if (Object.keys(events[currDay][timeStamp]).includes(currUserEmail)) {
+                                console.log(currUserEmail, " is UNAVAILABLE at the time: ", timeStamp, " on day: ", currDay);
+                                const currEvent = {
+                                    id: currId,
+                                    start: mstrTime.concat(":00"),
+                                    text: " ",
+                                    end: maddThirtyMin(currDay, mtime.clone()).concat(":00")
                                 }
+                                freeTimes.push(currEvent)
                             }
-                            mtime.add(30, 'm');
-
-                            if (seconds == ":00") {
-                                seconds = ":30"
-                            } else if (seconds == ":30") {
-                                seconds = ":00"
-                            }
-
-                            currId = currId + 1
-                            i += 1
                         }
-                        currTime = currTime + 1
-                    }
+                        mtime.add(30, 'm');
+                        currId = currId + 1
 
-                    currTime = 0 // Reset currTime for next date
+                    }
                 }
 
             }

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -166,21 +166,14 @@ class Calendar extends Component {
                             let timeStamp = convertTime(currTime).concat(seconds)
 
                             // CASE 1: Time slot where everybody is available
-                            if (!Object.keys(events[currDay]).includes(timeStamp)) {
-                                const currEvent = {
-                                    id: currId,
-                                    text: "ALL available",
-                                    start: strTime.concat(":00"),
-                                    end: addThirtyMin(currDay, currTime, seconds).concat(":00"),
-                                    backColor: "#" + colorSpectrum.colourAt(0)
-                                }
-                                freeTimes.push(currEvent)
-                            }
-                            // CASE 2: Time slot is not available for everyone
-                            else {
+                            if (Object.keys(events[currDay]).includes(timeStamp)) {
+                                
                                 const unavailable = events[currDay][timeStamp]
                                 const numUnavailable = Object.keys(unavailable).length
-                                const eventText = (numUsers - numUnavailable).toString() +
+                                //const eventText = (numUsers - numUnavailable).toString() +
+                                //    " / " + numUsers.toString() + " available"
+                                const eventText = (numUnavailable === 0) ? "ALL available" :
+                                    (numUsers - numUnavailable).toString() +
                                     " / " + numUsers.toString() + " available"
 
                                 const currEvent = {
@@ -211,7 +204,6 @@ class Calendar extends Component {
                     currTime = 0 // Reset currTime for next date
                 }
                 if (type === "PERSONAL") {
-                    // console.log("The logged in user's email: ", email)
                     const currUserEmail = normalEmailToFirebaseEmail(email);
                     var mtime = moment(currDay);
                     mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
@@ -219,8 +211,6 @@ class Calendar extends Component {
                         var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
                         let timeStamp = mtime.format('HH:mm');
                         if (Object.keys(events[currDay]).includes(timeStamp)) {
-                            //const unavailable = events[currDay][timeStamp]
-
                             if (Object.keys(events[currDay][timeStamp]).includes(currUserEmail)) {
                                 console.log(currUserEmail, " is UNAVAILABLE at the time: ", timeStamp, " on day: ", currDay);
                                 const currEvent = {
@@ -234,10 +224,8 @@ class Calendar extends Component {
                         }
                         mtime.add(30, 'm');
                         currId = currId + 1
-
                     }
                 }
-
             }
             )
         }

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -149,29 +149,23 @@ class Calendar extends Component {
             dates.forEach(function (key, dayIndex) {
                 let currId = 0
                 let currDay = dateToString(key)
-                let seconds = ":00"
 
                 if (!Object.keys(events).includes(currDay)) {
                     console.log("Date not included in firebase")
                 }
 
-                let strTime = currDay.concat("T", convertTime(currTime).concat(seconds))
-
                 if (type === "GROUP") {
-                    while (convertTime(currTime).concat(seconds) !== "24:00") {
-                        let i = 0
+                    var mtime = moment(currDay);
+                    mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+                    while (currDay == mtime.format('YYYY-MM-DD')) {
+                        
+                            var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
+                            let timeStamp = mtime.format('HH:mm');
 
-                        while (i < 2) {
-                            strTime = currDay.concat("T", convertTime(currTime).concat(seconds))
-                            let timeStamp = convertTime(currTime).concat(seconds)
-
-                            // CASE 1: Time slot where everybody is available
                             if (Object.keys(events[currDay]).includes(timeStamp)) {
                                 
                                 const unavailable = events[currDay][timeStamp]
                                 const numUnavailable = Object.keys(unavailable).length
-                                //const eventText = (numUsers - numUnavailable).toString() +
-                                //    " / " + numUsers.toString() + " available"
                                 const eventText = (numUnavailable === 0) ? "ALL available" :
                                     (numUsers - numUnavailable).toString() +
                                     " / " + numUsers.toString() + " available"
@@ -179,29 +173,17 @@ class Calendar extends Component {
                                 const currEvent = {
                                     id: currId,
                                     text: eventText,
-                                    start: strTime.concat(":00"),
-                                    end: addThirtyMin(currDay, currTime, seconds).concat(":00"),
+                                    start: mstrTime.concat(":00"),
+                                    end: maddThirtyMin(currDay, mtime.clone()).concat(":00"),
                                     backColor: "#" + colorSpectrum.colourAt(numUnavailable)
                                 }
 
                                 freeTimes.push(currEvent)
                             }
-
-                            //elif (prop)
-
-                            if (seconds == ":00") {
-                                seconds = ":30"
-                            } else if (seconds == ":30") {
-                                seconds = ":00"
-                            }
-
-                            currId = currId + 1
-                            i += 1
-                        }
-                        currTime = currTime + 1
+                            mtime.add(30, 'm');
+                            currId = currId + 1;                        
                     }
 
-                    currTime = 0 // Reset currTime for next date
                 }
                 if (type === "PERSONAL") {
                     const currUserEmail = normalEmailToFirebaseEmail(email);

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -8,7 +8,7 @@ import "./CalendarStyles.css"
 import "firebase/database"
 import {
     stringToDate, dateToString, convertTime,
-    addThirtyMin, createTimes, createDayArr
+    addThirtyMin, maddThirtyMin, createTimes, createDayArr
 } from "../../utilities"
 import { DATE_FORMAT, ROOM_ID } from "../../constants"
 import db from "../Db/firebaseConnect"
@@ -20,6 +20,7 @@ import { UserContext } from "../../context/UserContext"
 import normalEmailToFirebaseEmail from "../Utility/normalEmailToFirebaseEmail"
 
 var Rainbow = require("rainbowvis.js")
+
 
 const EventPage = () => {
     const userContext = useContext(UserContext)
@@ -212,13 +213,19 @@ class Calendar extends Component {
                 if (type === "PERSONAL") {
                     // console.log("The logged in user's email: ", email)
                     const currUserEmail = normalEmailToFirebaseEmail(email);
-                    while (convertTime(currTime).concat(seconds) !== "24:00") {
+                    var mtime = moment(currDay);
+                    mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+                    console.log('compare', currDay, currTime, mtime)
+                    while (currDay == mtime.format('YYYY-MM-DD')){//(convertTime(currTime).concat(seconds) !== "24:00") {
+                        var test = (currDay == mtime.format('YYYY-MM-DD'))
+                        console.log("dates", currDay, mtime.format('YYYY-MM-DD'), currDay == mtime.format('YYYY-MM-DD'), test)
                         let i = 0
-
                         while (i < 2) {
-
-                            strTime = currDay.concat("T", convertTime(currTime).concat(seconds))
-                            let timeStamp = convertTime(currTime).concat(seconds)
+                            console.log('compare', currDay, currTime, mtime,mtime.format('HH:mm'))
+                            //strTime = currDay.concat("T", convertTime(currTime).concat(seconds))
+                            var mstrTime = currDay.concat("T",mtime.format('HH:mm'));
+                            let timeStamp = mtime.format('HH:mm');//convertTime(currTime).concat(seconds)
+                            //console.log('comparestr', strTime, mstrTime)
 
                             // CASE 1: Time slot where everybody is available
                             if (Object.keys(events[currDay]).includes(timeStamp)) {
@@ -229,12 +236,13 @@ class Calendar extends Component {
                                     const currEvent = {
                                         id: currId,
                                         text: 'hi',
-                                        start: strTime.concat(":00"),
-                                        end: addThirtyMin(currDay, currTime, seconds).concat(":00")
+                                        start: mstrTime.concat(":00"),
+                                        end: maddThirtyMin(currDay, mtime.clone()).concat(":00")//addThirtyMin(currDay, currTime, seconds).concat(":00")
                                     }
                                     freeTimes.push(currEvent)
                                 }
                             }
+                            mtime.add(30, 'm');
 
                             if (seconds == ":00") {
                                 seconds = ":30"

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -143,8 +143,6 @@ class Calendar extends Component {
         colorSpectrum.setNumberRange(0, numUsers)
         colorSpectrum.setSpectrum("green", "red")
 
-        let currTime = 0
-
         if (events !== null) {
             dates.forEach(function (key, dayIndex) {
                 let currId = 0
@@ -153,46 +151,30 @@ class Calendar extends Component {
                 if (!Object.keys(events).includes(currDay)) {
                     console.log("Date not included in firebase")
                 }
+                const currUserEmail = normalEmailToFirebaseEmail(email);
+                var mtime = moment(currDay);
+                mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+                while (currDay == mtime.format('YYYY-MM-DD')) {
+                    var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
+                    let timeStamp = mtime.format('HH:mm');
+                    if (Object.keys(events[currDay]).includes(timeStamp)) {
+                        if (type === "GROUP") {
+                            const unavailable = events[currDay][timeStamp]
+                            const numUnavailable = Object.keys(unavailable).length
+                            const eventText = (numUnavailable === 0) ? "ALL available" :
+                                (numUsers - numUnavailable).toString() +
+                                " / " + numUsers.toString() + " available"
 
-                if (type === "GROUP") {
-                    var mtime = moment(currDay);
-                    mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-                    while (currDay == mtime.format('YYYY-MM-DD')) {
-                        
-                            var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
-                            let timeStamp = mtime.format('HH:mm');
-
-                            if (Object.keys(events[currDay]).includes(timeStamp)) {
-                                
-                                const unavailable = events[currDay][timeStamp]
-                                const numUnavailable = Object.keys(unavailable).length
-                                const eventText = (numUnavailable === 0) ? "ALL available" :
-                                    (numUsers - numUnavailable).toString() +
-                                    " / " + numUsers.toString() + " available"
-
-                                const currEvent = {
-                                    id: currId,
-                                    text: eventText,
-                                    start: mstrTime.concat(":00"),
-                                    end: maddThirtyMin(currDay, mtime.clone()).concat(":00"),
-                                    backColor: "#" + colorSpectrum.colourAt(numUnavailable)
-                                }
-
-                                freeTimes.push(currEvent)
+                            const currEvent = {
+                                id: currId,
+                                text: eventText,
+                                start: mstrTime.concat(":00"),
+                                end: maddThirtyMin(currDay, mtime.clone()).concat(":00"),
+                                backColor: "#" + colorSpectrum.colourAt(numUnavailable)
                             }
-                            mtime.add(30, 'm');
-                            currId = currId + 1;                        
-                    }
-
-                }
-                if (type === "PERSONAL") {
-                    const currUserEmail = normalEmailToFirebaseEmail(email);
-                    var mtime = moment(currDay);
-                    mtime.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-                    while (currDay == mtime.format('YYYY-MM-DD')) {
-                        var mstrTime = currDay.concat("T", mtime.format('HH:mm'));
-                        let timeStamp = mtime.format('HH:mm');
-                        if (Object.keys(events[currDay]).includes(timeStamp)) {
+                            freeTimes.push(currEvent)
+                        }
+                        if (type === "PERSONAL") {
                             if (Object.keys(events[currDay][timeStamp]).includes(currUserEmail)) {
                                 console.log(currUserEmail, " is UNAVAILABLE at the time: ", timeStamp, " on day: ", currDay);
                                 const currEvent = {
@@ -204,9 +186,10 @@ class Calendar extends Component {
                                 freeTimes.push(currEvent)
                             }
                         }
-                        mtime.add(30, 'm');
-                        currId = currId + 1
                     }
+                    mtime.add(30, 'm');
+                    currId = currId + 1
+
                 }
             }
             )

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -12,6 +12,10 @@ export function addThirtyMin(currDay, currTime, seconds) {
 }
 
 export function maddThirtyMin(currDay, mtime) {
+  if (mtime.format('HH:mm') == "23:30"){
+    const endTime = currDay.concat("T", "24:00");
+    return endTime;
+  }
   mtime.add(30, 'm');
   const endTime = currDay.concat("T",mtime.format('HH:mm'));
   return endTime

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,4 +1,5 @@
 import {DATE_FORMAT, HOURS, MINUTES} from "./constants"
+import moment from "moment";
 
 export function addThirtyMin(currDay, currTime, seconds) {
   if (seconds == ":00") {
@@ -8,6 +9,12 @@ export function addThirtyMin(currDay, currTime, seconds) {
     const endTime = currDay.concat("T", convertTime(currTime + 1).concat(":00"))
     return endTime
   }
+}
+
+export function maddThirtyMin(currDay, mtime) {
+  mtime.add(30, 'm');
+  const endTime = currDay.concat("T",mtime.format('HH:mm'));
+  return endTime
 }
 
 export function stringToDate(str) {


### PR DESCRIPTION
changed the calendar code to use moments instead of plain strings, simplified/fixed code
found an issue where the first day for some reason includes more times, and times that are not in range?
![image](https://user-images.githubusercontent.com/33076782/74110399-d539f180-4b51-11ea-8bf6-a20169463993.png)

http://localhost:3000/events/-M-franbKg3VNDBtlC-D

need to check if the issue is within Firebase code, need to only display the times in range and not rest. Otherwise can do it in the calendar code in another push.  Suzy is looking into something that might only display the specific time range in the calendar as well